### PR TITLE
Test and ensure consistent execution of queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 deno.lock
+.claude

--- a/src/command/queued/createQueuedCommandIssuer.test.ts
+++ b/src/command/queued/createQueuedCommandIssuer.test.ts
@@ -1,0 +1,118 @@
+import { beforeAll, describe, it } from "@std/testing/bdd";
+import { assertEquals } from "@std/assert";
+import { createQueuedCommandIssuer } from "./createQueuedCommandIssuer.ts";
+import { createPostgresEventStore } from "../../eventStore/createPostgresEventStore.ts";
+import {
+  createInMemorySnapshotStorage,
+  createSnapshottingAggregateRootRepository,
+} from "@ts-event-core/framework";
+import type { Event } from "@ts-event-core/framework";
+import { createTestConnection } from "../../../test/integration/utils/infra/testPostgresConnectionOptions.ts";
+import { prepareTestDatabaseContainer } from "../../../test/integration/utils/prepareTestDatabaseContainer.ts";
+
+import { tryThing } from "../../../test/integration/utils/tryThing.ts";
+
+type CounterState = {
+  count: number;
+  lastSequence: number;
+  inOrder: boolean;
+};
+
+type CounterEvent = {
+  type: "INCREMENTED";
+  sequenceNumber: number;
+  wasInOrder: boolean;
+};
+
+const counterAggregateRoot = {
+  state: {
+    version: 1,
+    initialState: { count: 0, lastSequence: 0, inOrder: true },
+    reducer: (state: CounterState, event: CounterEvent): CounterState => ({
+      count: state.count + 1,
+      lastSequence: event.sequenceNumber,
+      inOrder: state.inOrder && event.wasInOrder,
+    }),
+  },
+  commands: {
+    increment: (
+      state: CounterState,
+      data: { sequenceNumber: number },
+    ): CounterEvent => ({
+      type: "INCREMENTED",
+      sequenceNumber: data.sequenceNumber,
+      wasInOrder: data.sequenceNumber === state.lastSequence + 1,
+    }),
+  },
+};
+
+const COMMANDS_PER_AGGREGATE = 1000;
+const AGGREGATE_COUNT = 5;
+const WORKER_COUNT = 5;
+
+const connection = createTestConnection();
+
+describe("createQueuedCommandIssuer", () => {
+  beforeAll(prepareTestDatabaseContainer);
+
+  it("processes 1000 commands across 5 aggregates with FIFO ordering and no lost updates", async () => {
+    const eventStore = createPostgresEventStore<Event<CounterEvent>>({ connection });
+
+    const aggregateRoots = { COUNTER: counterAggregateRoot };
+    const aggregateRootRepository = createSnapshottingAggregateRootRepository({
+      aggregateRoots,
+      eventStore,
+      snapshotStorage: createInMemorySnapshotStorage(),
+    });
+
+    const { issueCommand, startQueueWorker } = createQueuedCommandIssuer({
+      connection,
+      aggregateRoots,
+      aggregateRootRepository,
+    });
+
+    const aggregateIds = Array.from(
+      { length: AGGREGATE_COUNT },
+      (_, i) => `counter-${i + 1}`,
+    );
+
+    for (const aggregateRootId of aggregateIds) {
+      for (let i = 0; i < COMMANDS_PER_AGGREGATE; i++) {
+        await issueCommand({
+          aggregateRootType: "COUNTER",
+          aggregateRootId,
+          command: "increment",
+          data: { sequenceNumber: i + 1 },
+        });
+      }
+    }
+
+    const workers = Array.from({ length: WORKER_COUNT }, () => startQueueWorker());
+
+    try {
+      await tryThing(async () => {
+        const [{ count }] = await connection`
+          SELECT count(*)::int as count FROM event_core.command_queue WHERE status = 'pending'
+        `;
+        assertEquals(count, 0);
+      });
+
+      const aggregates = await Promise.all(
+        aggregateIds.map((aggregateRootId) =>
+          aggregateRootRepository.retrieve({
+            aggregateRootType: "COUNTER",
+            aggregateRootId,
+          })
+        ),
+      );
+
+      assertEquals(
+        aggregates.map(({ state }) => ({ count: state.count, inOrder: state.inOrder })),
+        aggregateIds.map(() => ({ count: COMMANDS_PER_AGGREGATE, inOrder: true })),
+      );
+    } finally {
+      await Promise.all(workers.map((worker) => worker.halt()));
+      await connection.end();
+    }
+  });
+});

--- a/src/command/queued/createQueuedCommandIssuer.ts
+++ b/src/command/queued/createQueuedCommandIssuer.ts
@@ -8,7 +8,7 @@ import type postgres from "postgres";
 import type { JSONValue } from "npm:postgres@3.4.7";
 import { type QueueSignal, workQueue } from "./workQueue.ts";
 
-type QueuedCommandIssuer<
+export type QueuedCommandIssuer<
   TAggregateMap extends AggregateRootDefinitionMap<TAggregateMapTypes>,
   TAggregateMapTypes extends AggregateRootDefinitionMapTypes,
 > = {

--- a/src/command/queued/runPendingCommandFromQueue.ts
+++ b/src/command/queued/runPendingCommandFromQueue.ts
@@ -54,7 +54,8 @@ export async function runPendingCommandFromQueue<
         FROM event_core.command_queue inner_queue
         -- The use of FOR UPDATE will ensure we do not read a stale 'pending' status due to
         -- MVCC and transaction isolation levels, see https://www.postgresql.org/docs/current/transaction-iso.html:
-        -- > The search condition of the command (the WHERE clause) is re-evaluated to see if the updated version of the row still matches the search condition.
+        -- > The search condition of the command (the WHERE clause) is re-evaluated to see if the updated version of
+        -- > the row still matches the search condition.
         WHERE inner_queue.id = aggregates.oldest
         AND inner_queue.status = 'pending'
         FOR UPDATE SKIP LOCKED

--- a/src/command/queued/runPendingCommandFromQueue.ts
+++ b/src/command/queued/runPendingCommandFromQueue.ts
@@ -48,7 +48,8 @@ export async function runPendingCommandFromQueue<
     latest_unlocked_aggregate_command AS (
       SELECT queue.*
       FROM aggregates_with_pending_commands aggregates
-      -- Join to the aggregates oldest command, only if it is not locked.
+      -- Join to the aggregates oldest command on the condition it is not locked, moving on
+      -- to evaluate each candidate aggregate until a command is found.
       CROSS JOIN LATERAL (
         SELECT *
         FROM event_core.command_queue inner_queue

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export type { AggregateRootDefinition } from "./aggregate/AggregateRootDefinitio
 export type { EventsRaisedByAggregateRoots } from "./eventStore/EventStore.ts";
 export type { CommandIssuer } from "./command/CommandIssuer.ts";
 export type { Event } from "./eventStore/EventStore.ts";
+export type { QueuedCommandIssuer } from "./command/queued/createQueuedCommandIssuer.ts";
 
 /**
  * Exported functions.
@@ -27,3 +28,4 @@ export { createInMemoryEventStore } from "./eventStore/createInMemoryEventStore.
 export { createMemoryReducedProjector } from "./projection/createMemoryReducedProjector.ts";
 export { createBasicAggregateRootRepository } from "./aggregate/repository/createBasicAggregateRootRepository.ts";
 export { createPersistentLockingCursorPosition } from "./eventStore/cursor/createPersistentLockingCursorPosition.ts";
+export { createQueuedCommandIssuer } from "./command/queued/createQueuedCommandIssuer.ts";

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,11 @@
 /**
  * Exported types.
  */
+
 export type { AggregateRootDefinition } from "./aggregate/AggregateRootDefinition.ts";
 export type { EventsRaisedByAggregateRoots } from "./eventStore/EventStore.ts";
 export type { CommandIssuer } from "./command/CommandIssuer.ts";
+export type { Event } from "./eventStore/EventStore.ts";
 
 /**
  * Exported functions.

--- a/test/integration/utils/arrayOfSize.ts
+++ b/test/integration/utils/arrayOfSize.ts
@@ -1,0 +1,2 @@
+export const arrayOfSize = <T>(size: number, fn: (i: number) => T): T[] =>
+  Array.from({ length: size }, (_, i) => fn(i));

--- a/test/integration/utils/tryThing.ts
+++ b/test/integration/utils/tryThing.ts
@@ -5,11 +5,11 @@ export async function tryThing(thing: () => unknown) {
 
   const timer = setInterval(() => {
     status = "TIMEOUT_EXCEEDED";
-  }, 500);
+  }, 30_000);
 
   while (status !== "SUCCEEDED") {
     try {
-      thing();
+      await thing();
       status = "SUCCEEDED";
     } catch (e) {
       // @ts-expect-error - Is this a bug in typescript narrowing?


### PR DESCRIPTION
Currently reliably failing with:

```diff
    [
      {
-       count: 101,
-       inOrder: false,
+       count: 100,
+       inOrder: true,
        lastSequence: 100,
      },
      {
        count: 100,
        inOrder: true,
        lastSequence: 100,
      },
      {
-       count: 101,
-       inOrder: false,
+       count: 100,
+       inOrder: true,
        lastSequence: 100,
      },
      {
        count: 100,
        inOrder: true,
        lastSequence: 100,
      },
      {
        count: 100,
        inOrder: true,
        lastSequence: 100,
      },
    ]
```